### PR TITLE
Fix typo in German footer link

### DIFF
--- a/layouts/partials/footer/custom.html
+++ b/layouts/partials/footer/custom.html
@@ -20,7 +20,7 @@
         } else {
             document.getElementById("legal-notice-link").textContent = "Impressum";
             document.getElementById("legal-notice-link").href = "/de/legal_notice/";
-            document.getElementById("privacy-policy-link").textContent = "Datenshutz";
+            document.getElementById("privacy-policy-link").textContent = "Datenschutz";
             document.getElementById("privacy-policy-link").href = "/de/privacy_policy/";
             document.getElementById("contact-link").textContent = "Kontakt";
             document.getElementById("contact-link").href = "/de/contact/";


### PR DESCRIPTION
## Summary
- correct German privacy policy link text

## Testing
- `pre-commit run --files layouts/partials/footer/custom.html` *(fails: pre-commit not found)*
- `pip install -r requirements.txt` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68528c6ce61083289b10ba6cc67e8087